### PR TITLE
Accessibility audit fixes (not PDF related)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,0 +1,6 @@
+.js-visible {
+  display: none !important;
+}
+.js-enabled .js-visible {
+  display: inline-block !important;
+}

--- a/app/forms/mappings/Formatters.scala
+++ b/app/forms/mappings/Formatters.scala
@@ -65,6 +65,7 @@ trait Formatters {
         baseFormatter
           .bind(key, data)
           .right.map(_.replace(",", ""))
+          .right.map(_.replace(" ", ""))
           .right.flatMap {
           case s if s.matches(decimalRegexp) =>
             Left(Seq(FormError(key, wholeNumberKey, args)))

--- a/app/views/ErrorTemplate.scala.html
+++ b/app/views/ErrorTemplate.scala.html
@@ -20,7 +20,7 @@
 
 @(pageTitle: String, heading: String, message: String)(implicit request: Request[_], messages: Messages)
 
-@layout(pageTitle = titleNoForm(pageTitle)) {
+@layout(pageTitle = titleNoForm(pageTitle), showBackLink = false) {
     <h1 class="govuk-heading-xl">@messages(heading)</h1>
 
     <p class="govuk-body">@messages(message)</p>

--- a/app/views/IndexView.scala.html
+++ b/app/views/IndexView.scala.html
@@ -21,7 +21,8 @@
 @()(implicit request: Request[_], messages: Messages)
 
 @layout(
-    pageTitle    = titleNoForm(messages("index.title")),
+    pageTitle    = indexTitle(),
+    linkToIndexPage = false,
     showBackLink = false
 ) {
 

--- a/app/views/JourneyRecoveryContinueView.scala.html
+++ b/app/views/JourneyRecoveryContinueView.scala.html
@@ -21,7 +21,7 @@
 
 @(continueUrl: String)(implicit request: Request[_], messages: Messages)
 
-@layout(pageTitle = titleNoForm(messages("journeyRecovery.continue.title"))) {
+@layout(pageTitle = titleNoForm(messages("journeyRecovery.continue.title")), showBackLink = false) {
 
     <h1 class="govuk-heading-xl">@messages("journeyRecovery.continue.heading")</h1>
 

--- a/app/views/JourneyRecoveryStartAgainView.scala.html
+++ b/app/views/JourneyRecoveryStartAgainView.scala.html
@@ -21,7 +21,7 @@
 
 @()(implicit request: Request[_], messages: Messages)
 
-@layout(pageTitle = titleNoForm(messages("journeyRecovery.startAgain.title"))) {
+@layout(pageTitle = titleNoForm(messages("journeyRecovery.startAgain.title")), showBackLink = false) {
 
     <h1 class="govuk-heading-xl">@messages("journeyRecovery.startAgain.heading")</h1>
 

--- a/app/views/NameView.scala.html
+++ b/app/views/NameView.scala.html
@@ -47,6 +47,7 @@
             )
             .withWidth(Full)
             .withAutocomplete("given-name")
+            .withAttribute("spellcheck", "false")
         )
 
         @govukInput(
@@ -56,6 +57,7 @@
             )
             .withWidth(Full)
             .withAutocomplete("family-name")
+            .withAttribute("spellcheck", "false")
         )
 
         @govukButton(

--- a/app/views/NinoView.scala.html
+++ b/app/views/NinoView.scala.html
@@ -44,6 +44,7 @@
             )
             .withWidth(Fixed10)
             .withHint(HintViewModel(messages("nino.hint")))
+            .withAttribute("spellcheck", "false")
         )
 
         @govukButton(

--- a/app/views/ViewUtils.scala
+++ b/app/views/ViewUtils.scala
@@ -30,6 +30,9 @@ object ViewUtils {
       section = section
     )
 
+  def indexTitle()(implicit messages: Messages): String =
+    s"${messages("service.name")} - ${messages("site.govuk")}"
+
   def titleNoForm(title: String, section: Option[String] = None)(implicit messages: Messages): String =
     s"${messages(title)} - ${section.fold("")(messages(_) + " - ")}${messages("service.name")} - ${messages("site.govuk")}"
 

--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -51,6 +51,8 @@
             )))
         } else None
     )
+
+    <link href="@routes.Assets.versioned("stylesheets/application.css")" media="all" rel="stylesheet" type="text/css"@CSPNonce.get.map {n=> nonce="@n"} />
 }
 
 @additionalScripts = {
@@ -68,7 +70,7 @@
     }
 
     @if(showBackLink) {
-        @govukBackLink(BackLinkViewModel(href = "#"))
+        @govukBackLink(BackLinkViewModel(href = "#").withCssClass("js-visible"))
     }
 }
 

--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -32,7 +32,7 @@
     betaBanner: StandardBetaBanner
 )
 
-@(pageTitle: String, showBackLink: Boolean = true, timeout: Boolean = true, showSignOut: Boolean = false)(contentBlock: Html)(implicit request: Request[_], messages: Messages)
+@(pageTitle: String, showBackLink: Boolean = true, timeout: Boolean = true, showSignOut: Boolean = false, linkToIndexPage: Boolean = true)(contentBlock: Html)(implicit request: Request[_], messages: Messages)
 
 @head = {
 
@@ -84,7 +84,7 @@
     pageTitle   = Some(pageTitle),
     headBlock   = Some(head),
     headerBlock = Some(hmrcStandardHeader(
-        serviceUrl  = Some(routes.IndexController.onPageLoad.url),
+        serviceUrl  = if(linkToIndexPage) Some(routes.IndexController.onPageLoad.url) else None,
         signOutUrl  = if(showSignOut) Some(controllers.auth.routes.AuthController.signOut.url) else None,
         phaseBanner = Some(betaBanner(appConfig.feedbackUrl))
     )),

--- a/test/forms/mappings/MappingsSpec.scala
+++ b/test/forms/mappings/MappingsSpec.scala
@@ -141,6 +141,16 @@ class MappingsSpec extends AnyFreeSpec with Matchers with OptionValues with Mapp
       result.get mustEqual 1
     }
 
+    "must bind a valid integer containing a space" in {
+      val result = testForm.bind(Map("value" -> "1 000"))
+      result.get mustEqual 1000
+    }
+
+    "must bind a valid integer containing a comma" in {
+      val result = testForm.bind(Map("value" -> "1,000"))
+      result.get mustEqual 1000
+    }
+
     "must not bind an empty value" in {
       val result = testForm.bind(Map("value" -> ""))
       result.errors must contain(FormError("value", "error.required"))


### PR DESCRIPTION
- Allowing spaces in int and date fields (hmrc/accessibility-audits-external#4320)
- Disabling back links on error pages (hmrc/accessibility-audits-external#4321)
- Fixing start page accessibility issues (hmrc/accessibility-audits-external#4322)
- Hiding back link when JS is disabled (hmrc/accessibility-audits-external#4318)
- Adding spellcheck=false attributes (hmrc/accessibility-audits-external#4319)
